### PR TITLE
Thread ID and VC++ SetThreadName support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,8 +71,8 @@ endmacro ()
 
 # We require at least GCC 4.9 for decent C++11 support
 if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
-    CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.9")
-    message (FATAL_ERROR "GCC 4.9 or newer required")
+    CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.8")
+    message (FATAL_ERROR "GCC 4.8 or newer required")
 endif ()
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")

--- a/src/common/debugger.cpp
+++ b/src/common/debugger.cpp
@@ -421,7 +421,7 @@ BOOL DebugMainLoop(const DebugOptions *pOptions)
                  *
                  * TODO: Note down the thread name
                  */
-                if (ExceptionCode == 0x406d1388) {
+		if (ExceptionCode == MS_VC_SET_THREAD_NAME_EXCEPTION) {
                     dwContinueStatus = DBG_CONTINUE;
                     break;
                 }

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -430,7 +430,7 @@ getExceptionString(DWORD ExceptionCode)
         return "Control+C";
     case DBG_CONTROL_BREAK: // 0x40010008
         return "Control+Break";
-    case 0x406D1388:
+    case MS_VC_SET_THREAD_NAME_EXCEPTION:
         return "Thread Name Exception";
 
     case RPC_S_UNKNOWN_IF:

--- a/src/common/log.h
+++ b/src/common/log.h
@@ -20,6 +20,7 @@
 
 #include <windows.h>
 
+#define MS_VC_SET_THREAD_NAME_EXCEPTION 0x406d1388
 
 typedef void (*DumpCallback)(const char *);
 

--- a/src/exchndl/exchndl.cpp
+++ b/src/exchndl/exchndl.cpp
@@ -38,7 +38,7 @@ static LPTOP_LEVEL_EXCEPTION_FILTER g_prevExceptionFilter = NULL;
 static char g_szLogFileName[MAX_PATH] = "";
 static HANDLE g_hReportFile;
 static BOOL g_bOwnReportFile;
-static DWORD g_dwSetupTreadId = 0;
+static DWORD g_dwSetupThreadId = 0;
 
 static void
 writeReport(const char *szText)
@@ -66,7 +66,7 @@ static
 void dumpThreadInfo()
 {
     lprintf("Current Thread ID: %lu\n", GetCurrentThreadId());
-    lprintf("  Setup Thread ID: %lu (probably main thread)\n\n", g_dwSetupTreadId);
+    lprintf("  Setup Thread ID: %lu (probably main thread)\n\n", g_dwSetupThreadId);
 }
 
 static
@@ -218,7 +218,7 @@ Setup(void)
         }
     }
 
-    g_dwSetupTreadId = GetCurrentThreadId();
+    g_dwSetupThreadId = GetCurrentThreadId();
 }
 
 

--- a/src/exchndl/exchndl.cpp
+++ b/src/exchndl/exchndl.cpp
@@ -32,13 +32,13 @@
 
 #define REPORT_FILE 1
 
-
 // Declare the static variables
 static BOOL g_bHandlerSet = FALSE;
 static LPTOP_LEVEL_EXCEPTION_FILTER g_prevExceptionFilter = NULL;
 static char g_szLogFileName[MAX_PATH] = "";
 static HANDLE g_hReportFile;
 static BOOL g_bOwnReportFile;
+static DWORD g_dwSetupTreadId = 0;
 
 static void
 writeReport(const char *szText)
@@ -62,6 +62,12 @@ writeReport(const char *szText)
     }
 }
 
+static
+void dumpThreadInfo()
+{
+    lprintf("Current Thread ID: %lu\n", GetCurrentThreadId());
+    lprintf("  Setup Thread ID: %lu (probably main thread)\n\n", g_dwSetupTreadId);
+}
 
 static
 void GenerateExceptionReport(PEXCEPTION_POINTERS pExceptionInfo)
@@ -87,6 +93,8 @@ void GenerateExceptionReport(PEXCEPTION_POINTERS pExceptionInfo)
     if (InitializeSym(hProcess, TRUE)) {
 
         dumpException(hProcess, pExceptionRecord);
+
+	dumpThreadInfo();
 
         PCONTEXT pContext = pExceptionInfo->ContextRecord;
 
@@ -209,6 +217,8 @@ Setup(void)
             strcat(g_szLogFileName, "EXCHNDL.RPT");
         }
     }
+
+    g_dwSetupTreadId = GetCurrentThreadId();
 }
 
 


### PR DESCRIPTION
This fork:
- relaxes GCC requirement to 4.8 (works fine with mingw 4.8.2)
- includes Thread ID and Setup Thread ID (the thread that exception handler was initialized on) in the crash report. This is to allow determining if crash happened on main thread or background thread. This is very useful for multithreaded apps.
- Ignores so called VC++ SetThreadName exception, this is not an actual error so it should not cause crash report generation