### PR TITLE
Fix misc. README and source comment typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To resolve the addresses it's necessary to compile the application with debuggin
 
 ## Command Line Options
 
-The following table describes the Dr. Mingw command-line options.  All comand-line options are case-sensitive.
+The following table describes the Dr. Mingw command-line options.  All command-line options are case-sensitive.
 
 | Short          | Long                   | Action |
 | -------------- | ---------------------- | ------ |

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -313,7 +313,7 @@ dumpStack(HANDLE hProcess, HANDLE hThread,
          * address.  This could be the next statement, or sometimes (for
          * no-return functions) a completely different function, so nudge the
          * address by one byte to ensure we get the information about the
-         * calling statment itself.
+         * calling statement itself.
          */
         nudge = -1;
     }

--- a/src/drmingw/dialog.cpp
+++ b/src/drmingw/dialog.cpp
@@ -86,7 +86,7 @@ WndProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
             SendDlgItemMessage(hwnd, IDC_MESSAGE, EM_SETBKGNDCOLOR, FALSE, dwColor);
 
             // We used to use GetStockObject(ANSI_FIXED_FONT), but it's known
-            // to lead to unreliable results, particularly on Russion locales
+            // to lead to unreliable results, particularly on Russian locales
             // or high-DPI displays, so now we match Notepad's default font.
             LOGFONTA lf = {
                 10,                      // lfHeight


### PR DESCRIPTION
Found via `codespell -q 3 -S ./thirdparty -L doas,uint`