### PR TITLE
build: use cmake's CMAKE_DLLTOOL instead of manually finding DLLTOOL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.1)
+cmake_minimum_required (VERSION 3.16)
 
 
 project (drmingw)
@@ -39,19 +39,6 @@ include_directories (
 add_subdirectory (thirdparty/dwarf)
 add_subdirectory (thirdparty/libiberty)
 add_subdirectory (thirdparty/zlib)
-
-# Find dlltool
-get_filename_component (GCC_NAME ${CMAKE_C_COMPILER} NAME)
-string (REGEX REPLACE g?cc dlltool DLLTOOL_NAME ${GCC_NAME})
-if (NOT DLLTOOL_NAME MATCHES dlltool)
-    message (FATAL_ERROR "Best guessing the file name of dlltool failed: ${DLLTOOL_NAME}")
-endif ()
-find_program (DLLTOOL NAMES ${DLLTOOL_NAME})
-if (DLLTOOL)
-    message (STATUS "Found dlltool: ${DLLTOOL}")
-else ()
-    message (FATAL_ERROR "dlltool not found")
-endif ()
 
 
 ##############################################################################

--- a/src/exchndl/CMakeLists.txt
+++ b/src/exchndl/CMakeLists.txt
@@ -28,7 +28,7 @@ install (TARGETS exchndl LIBRARY DESTINATION bin)
 
 add_custom_command (
     OUTPUT ${EXCHNDL_IMPLIB}
-    COMMAND ${DLLTOOL} --output-lib ${EXCHNDL_IMPLIB} --kill-at --input-def=${CMAKE_CURRENT_SOURCE_DIR}/${EXCHNDL_IMP_DEF}
+    COMMAND ${CMAKE_DLLTOOL} --output-lib ${EXCHNDL_IMPLIB} --kill-at --input-def=${CMAKE_CURRENT_SOURCE_DIR}/${EXCHNDL_IMP_DEF}
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${EXCHNDL_IMP_DEF}
 )
 add_custom_target (exchndl_implib ALL DEPENDS exchndl ${EXCHNDL_IMPLIB})

--- a/src/mgwhelp/CMakeLists.txt
+++ b/src/mgwhelp/CMakeLists.txt
@@ -29,7 +29,7 @@ install (TARGETS mgwhelp LIBRARY DESTINATION bin)
 
 add_custom_command (
     OUTPUT ${MGWHELP_IMPLIB}
-    COMMAND ${DLLTOOL} --output-lib ${MGWHELP_IMPLIB} --dllname mgwhelp.dll --kill-at --input-def=${CMAKE_CURRENT_SOURCE_DIR}/${MGWHELP_IMP_DEF}
+    COMMAND ${CMAKE_DLLTOOL} --output-lib ${MGWHELP_IMPLIB} --dllname mgwhelp.dll --kill-at --input-def=${CMAKE_CURRENT_SOURCE_DIR}/${MGWHELP_IMP_DEF}
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${MGWHELP_IMP_DEF}
 )
 add_custom_target (mgwhelp_implib DEPENDS mgwhelp ${MGWHELP_IMPLIB})


### PR DESCRIPTION
cmake 3.16 learned how to find the dlltool of the used toolchain.

* CMakeLists.txt:
  - increase required cmake version to 3.16
  - remove block finding DLLTOOL
* src/exchndl/CMakeLists.txt: replace DLLTOOL by CMAKE_DLLTOOL
* src/mgwhelp/CMakeLists.txt: same