### PR TITLE
compile fix for newer gcc

### DIFF
--- a/src/common/debugger.cpp
+++ b/src/common/debugger.cpp
@@ -18,6 +18,7 @@
 
 
 #include <map>
+#include <string>
 
 #include <assert.h>
 #include <stdlib.h>


### PR DESCRIPTION
string needs to be explicitly included otherwise it doesn't compile with newer gcc