### PR TITLE
Add offset from symbol address to stack dump

### DIFF
--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -223,6 +223,7 @@ dumpStack(HANDLE hProcess, HANDLE hThread, const CONTEXT *pContext)
 
         BOOL bSymbol = TRUE;
         BOOL bLine = FALSE;
+        DWORD dwOffsetFromSymbol = 0;
 
         DWORD64 AddrPC = StackFrame.AddrPC.Offset;
         HMODULE hModule = (HMODULE)(INT_PTR)SymGetModuleBase64(hProcess, AddrPC);
@@ -230,9 +231,10 @@ dumpStack(HANDLE hProcess, HANDLE hThread, const CONTEXT *pContext)
         if (hModule && GetModuleFileNameExA(hProcess, hModule, szModule, MAX_PATH)) {
             lprintf("  %s", getBaseName(szModule));
 
-            bSymbol = GetSymFromAddr(hProcess, AddrPC + nudge, szSymName, MAX_SYM_NAME_SIZE);
+            bSymbol = GetSymFromAddr(hProcess, AddrPC + nudge, szSymName, MAX_SYM_NAME_SIZE,
+                                     &dwOffsetFromSymbol);
             if (bSymbol) {
-                lprintf("!%s", szSymName);
+                lprintf("!%s+0x%lx", szSymName, dwOffsetFromSymbol - nudge);
 
                 bLine =
                     GetLineFromAddr(hProcess, AddrPC + nudge, szFileName, MAX_PATH, &dwLineNumber);

--- a/src/common/symbols.cpp
+++ b/src/common/symbols.cpp
@@ -91,7 +91,11 @@ InitializeSym(HANDLE hProcess, BOOL fInvadeProcess)
 
 
 BOOL
-GetSymFromAddr(HANDLE hProcess, DWORD64 dwAddress, LPSTR lpSymName, DWORD nSize)
+GetSymFromAddr(HANDLE hProcess,
+               DWORD64 dwAddress,
+               LPSTR lpSymName,
+               DWORD nSize,
+               LPDWORD lpdwDisplacement)
 {
     PSYMBOL_INFO pSymbol = (PSYMBOL_INFO)malloc(sizeof(SYMBOL_INFO) + nSize * sizeof(char));
 
@@ -111,6 +115,9 @@ GetSymFromAddr(HANDLE hProcess, DWORD64 dwAddress, LPSTR lpSymName, DWORD nSize)
         if ((dwOptions & SYMOPT_UNDNAME) ||
             UnDecorateSymbolName(pSymbol->Name, lpSymName, nSize, UNDNAME_NAME_ONLY) == 0) {
             strncpy(lpSymName, pSymbol->Name, nSize);
+        }
+        if (lpdwDisplacement) {
+            *lpdwDisplacement = dwDisplacement;
         }
     }
 

--- a/src/common/symbols.h
+++ b/src/common/symbols.h
@@ -28,7 +28,11 @@ EXTERN_C BOOL
 InitializeSym(HANDLE hProcess, BOOL fInvadeProcess);
 
 EXTERN_C BOOL
-GetSymFromAddr(HANDLE hProcess, DWORD64 dwAddress, LPSTR lpSymName, DWORD nSize);
+GetSymFromAddr(HANDLE hProcess,
+               DWORD64 dwAddress,
+               LPSTR lpSymName,
+               DWORD nSize,
+               LPDWORD lpdwDisplacement);
 
 EXTERN_C BOOL
 GetLineFromAddr(HANDLE hProcess,

--- a/src/mgwhelp/dwarf_find.cpp
+++ b/src/mgwhelp/dwarf_find.cpp
@@ -40,7 +40,11 @@ static char unknown[] = {'?', '?', '\0'};
 
 
 static bool
-search_func(Dwarf_Debug dbg, Dwarf_Die *die, Dwarf_Addr addr, std::string &rlt_func)
+search_func(Dwarf_Debug dbg,
+            Dwarf_Die *die,
+            Dwarf_Addr addr,
+            unsigned int *offset_addr,
+            std::string &rlt_func)
 {
     Dwarf_Die spec_die;
     Dwarf_Die child_die;
@@ -72,6 +76,7 @@ search_func(Dwarf_Debug dbg, Dwarf_Die *die, Dwarf_Addr addr, std::string &rlt_f
 
             /* Found it! */
 
+            *offset_addr = addr - lopc;
             rlt_func = unknown;
             ret = dwarf_attr(*die, DW_AT_name, &sub_at, &de);
             if (ret == DW_DLV_ERROR)
@@ -132,7 +137,7 @@ cont_search:
         if (ret == DW_DLV_ERROR)
             OutputDebug("MGWHELP: dwarf_child failed - %s\n", dwarf_errmsg(de));
         else if (ret == DW_DLV_OK) {
-            result = search_func(dbg, &child_die, addr, rlt_func);
+            result = search_func(dbg, &child_die, addr, offset_addr, rlt_func);
             dwarf_dealloc(dbg, child_die, DW_DLA_DIE);
             if (result) {
                 return true;
@@ -175,7 +180,7 @@ dwarf_find_symbol(dwarf_module *dwarf, Dwarf_Addr addr, struct dwarf_symbol_info
         goto no_cu_die;
     }
 
-    result = search_func(dbg, &cu_die, addr, info->functionname);
+    result = search_func(dbg, &cu_die, addr, &info->offset_addr, info->functionname);
 
     dwarf_dealloc(dbg, cu_die, DW_DLA_DIE);
 no_cu_die:;
@@ -193,6 +198,7 @@ dwarf_find_line(dwarf_module *dwarf, Dwarf_Addr addr, struct dwarf_line_info *in
     bool result = false;
     Dwarf_Error error = 0;
     std::string symbol_name;
+    unsigned int offset_addr;
 
     Dwarf_Debug dbg = dwarf->dbg;
 
@@ -213,7 +219,7 @@ dwarf_find_line(dwarf_module *dwarf, Dwarf_Addr addr, struct dwarf_line_info *in
 
     Dwarf_Line *linebuf;
     Dwarf_Signed linecount;
-    if (search_func(dbg, &cu_die, addr, symbol_name) &&
+    if (search_func(dbg, &cu_die, addr, &offset_addr, symbol_name) &&
         dwarf_srclines(cu_die, &linebuf, &linecount, &error) == DW_DLV_OK) {
         Dwarf_Unsigned lineno, plineno;
         Dwarf_Addr lineaddr, plineaddr;
@@ -289,6 +295,7 @@ dwarf_find_line(dwarf_module *dwarf, Dwarf_Addr addr, struct dwarf_line_info *in
         if (result && file) {
             info->filename = file;
             info->line = lineno;
+            info->offset_addr = offset_addr;
         }
         if (file) {
             dwarf_dealloc(dbg, file, DW_DLA_STRING);

--- a/src/mgwhelp/dwarf_find.h
+++ b/src/mgwhelp/dwarf_find.h
@@ -34,11 +34,13 @@ extern "C" {
 
 struct dwarf_symbol_info {
     std::string functionname;
+    unsigned int offset_addr;
 };
 
 struct dwarf_line_info {
     std::string filename;
     unsigned int line = 0;
+    unsigned int offset_addr;
 };
 
 struct dwarf_module {

--- a/src/mgwhelp/mgwhelp.cpp
+++ b/src/mgwhelp/mgwhelp.cpp
@@ -594,8 +594,7 @@ MgwSymFromAddr(HANDLE hProcess, DWORD64 Address, PDWORD64 Displacement, PSYMBOL_
                 }
             }
             if (Displacement) {
-                /* TODO */
-                *Displacement = 0;
+                *Displacement = info.offset_addr;
             }
             return TRUE;
         }
@@ -623,8 +622,7 @@ MgwSymGetLineFromAddr64(HANDLE hProcess,
             Line->LineNumber = info.line;
 
             if (pdwDisplacement) {
-                /* TODO */
-                *pdwDisplacement = 0;
+                *pdwDisplacement = info.offset_addr;
             }
             return TRUE;
         }

--- a/tests/apps/access_violation.c
+++ b/tests/apps/access_violation.c
@@ -33,5 +33,5 @@ main(int argc, char *argv[])
     return 0;
 }
 
-// CHECK_STDERR: /  access_violation\.exe\!main  \[.*\baccess_violation\.c @ 31\]/
+// CHECK_STDERR: /  access_violation\.exe\!main\+0x[0-9a-f]+  \[.*\baccess_violation\.c @ 31\]/
 // CHECK_EXIT_CODE: 0xc0000005

--- a/tests/apps/access_violation_cxx.cpp
+++ b/tests/apps/access_violation_cxx.cpp
@@ -41,5 +41,5 @@ main(int argc, char *argv[])
     return 0;
 }
 
-// CHECK_STDERR: /  access_violation_cxx\.exe\!test  \[.*\baccess_violation_cxx\.cpp @ 34\]/
+// CHECK_STDERR: /  access_violation_cxx\.exe\!test\+0x[0-9a-f]+  \[.*\baccess_violation_cxx\.cpp @ 34\]/
 // CHECK_EXIT_CODE: 0xc0000005

--- a/tests/apps/ctrl_break.c
+++ b/tests/apps/ctrl_break.c
@@ -38,5 +38,5 @@ main(int argc, char *argv[])
 }
 
 // CHECK_STDERR: /^catchsegv: warning: caught Ctrl-Break event/
-// CHECK_STDERR: /  ctrl_break\.exe\!main  \[.*\bctrl_break\.c @ 36\]/
+// CHECK_STDERR: /  ctrl_break\.exe\!main\+0x[0-9a-f]+  \[.*\bctrl_break\.c @ 36\]/
 // CHECK_EXIT_CODE: 0

--- a/tests/apps/ctrl_c.c
+++ b/tests/apps/ctrl_c.c
@@ -38,5 +38,5 @@ main(int argc, char *argv[])
 }
 
 // CHECK_STDERR: /^catchsegv: warning: caught Ctrl-C event/
-// CHECK_STDERR: /  ctrl_c\.exe\!main  \[.*\bctrl_c\.c @ 36\]/
+// CHECK_STDERR: /  ctrl_c\.exe\!main\+0x[0-9a-f]+  \[.*\bctrl_c\.c @ 36\]/
 // CHECK_EXIT_CODE: 0

--- a/tests/apps/cxx_inline.cpp
+++ b/tests/apps/cxx_inline.cpp
@@ -29,5 +29,5 @@ int main()
     return l != 0;
 }
 
-// CHECK_STDERR: /  cxx_inline\.exe\!main  \[.*\bcxx_inline\.cpp @ (21|28)\]/
+// CHECK_STDERR: /  cxx_inline\.exe\!main\+0x[0-9a-f]+  \[.*\bcxx_inline\.cpp @ (21|28)\]/
 // CHECK_EXIT_CODE: 0xc0000005

--- a/tests/apps/int3.c
+++ b/tests/apps/int3.c
@@ -41,5 +41,5 @@ main(int argc, char *argv[])
     return 0;
 }
 
-// CHECK_STDERR: /  int3\.exe\!main  \[.*\bint3\.c @ 39\]/
+// CHECK_STDERR: /  int3\.exe\!main\+0x[0-9a-f]+  \[.*\bint3\.c @ 39\]/
 // CHECK_EXIT_CODE: 0x80000003

--- a/tests/apps/int_divide_by_zero.c
+++ b/tests/apps/int_divide_by_zero.c
@@ -36,5 +36,5 @@ main(int argc, char *argv[])
     return res.quot;
 }
 
-// CHECK_STDERR: /  int_divide_by_zero\.exe\!main  \[.*\bint_divide_by_zero\.c @ 35\]/
+// CHECK_STDERR: /  int_divide_by_zero\.exe\!main\+0x[0-9a-f]+  \[.*\bint_divide_by_zero\.c @ 35\]/
 // CHECK_EXIT_CODE: 0xC0000094

--- a/tests/apps/int_overflow.c
+++ b/tests/apps/int_overflow.c
@@ -36,4 +36,4 @@ main(int argc, char *argv[])
     return res.quot;
 }
 
-// CHECK_STDERR: /  int_overflow\.exe\!main  \[.*\bint_overflow\.c @ 35\]/
+// CHECK_STDERR: /  int_overflow\.exe\!main\+0x[0-9a-f]+  \[.*\bint_overflow\.c @ 35\]/

--- a/tests/apps/invalid_parameter.c
+++ b/tests/apps/invalid_parameter.c
@@ -41,5 +41,5 @@ int main()
     return 125;
 }
 
-// CHECK_STDERR: /!_invalid_parameter  /
+// CHECK_STDERR: /!_invalid_parameter\+0x[0-9a-f]+  /
 // CHECK_EXIT_CODE: !0

--- a/tests/apps/invoke_watson.c
+++ b/tests/apps/invoke_watson.c
@@ -41,5 +41,5 @@ int main()
     return 125;
 }
 
-// CHECK_STDERR: /!_invoke_watson  /
+// CHECK_STDERR: /!_invoke_watson\+0x[0-9a-f]+  /
 // CHECK_EXIT_CODE: !0

--- a/tests/apps/seh_unhandled.c
+++ b/tests/apps/seh_unhandled.c
@@ -46,5 +46,5 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdS
     return 0;
 }
 
-// CHECK_STDERR: /  seh_unhandled\.exe\!WinMain(@16)?  \[.*\bseh_unhandled\.c @ 44\]/
+// CHECK_STDERR: /  seh_unhandled\.exe\!WinMain(@16)?\+0x[0-9a-f]+  \[.*\bseh_unhandled\.c @ 44\]/
 // CHECK_EXIT_CODE: 0xE0000001

--- a/tests/apps/stack_overflow.c
+++ b/tests/apps/stack_overflow.c
@@ -71,6 +71,6 @@ int main()
     return 0;
 }
 
-// CHECK_STDERR: /  stack_overflow\.exe\!factorial  \[.*\bstack_overflow\.c @ 38\]/
-// CHECK_STDERR: /  stack_overflow\.exe\!main  \[.*\bstack_overflow\.c @ 69\]/
+// CHECK_STDERR: /  stack_overflow\.exe\!factorial\+0x[0-9a-f]+  \[.*\bstack_overflow\.c @ 38\]/
+// CHECK_STDERR: /  stack_overflow\.exe\!main\+0x[0-9a-f]+  \[.*\bstack_overflow\.c @ 69\]/
 // CHECK_EXIT_CODE: 0xc00000fd

--- a/tests/apps/ud2.c
+++ b/tests/apps/ud2.c
@@ -41,5 +41,5 @@ main(int argc, char *argv[])
     return 0;
 }
 
-// CHECK_STDERR: /  ud2\.exe\!main  \[.*\bud2\.c @ 39\]/
+// CHECK_STDERR: /  ud2\.exe\!main\+0x[0-9a-f]+  \[.*\bud2\.c @ 39\]/
 // CHECK_EXIT_CODE: 0xC000001D

--- a/tests/test_exchndl.h
+++ b/tests/test_exchndl.h
@@ -118,7 +118,7 @@ main(int argc, char **argv)
 
 #endif
 
-    _snprintf(g_szExceptionFunctionPattern, sizeof g_szExceptionFunctionPattern, " %s!%s ", PROG_NAME ".exe", __FUNCTION__);
+    _snprintf(g_szExceptionFunctionPattern, sizeof g_szExceptionFunctionPattern, " %s!%s+0x", PROG_NAME ".exe", __FUNCTION__);
 
     if (!setjmp(g_JmpBuf) ) {
         _snprintf(g_szExceptionLinePattern, sizeof g_szExceptionLinePattern, "%s @ %u]",


### PR DESCRIPTION
Re-created https://github.com/alvinhochun/drmingw/commit/25e5211e95dfa6418cbbb151af0ac3f6786a1480 with tests added for the Displacement out parameter of `MgwSymFromAddr` and `MgwSymGetLineFromAddr64`.

A difference in this version is that the address-relative-to-module-start (`AddrPC - (DWORD64)(INT_PTR)hModule`)is not printed. I thought it seems not really useful.

For `test_exchndl_static` and `test_exchndl_dynamic` I don't have a good way to get the offset, so it now only test for ` test_exchndl_static.exe!main+0x` without the actual offset address.

Closes #32