### PR TITLE
Minor fixes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The following table describes the Dr. Mingw command-line options.  All command-l
 
 The MgwHelp library aims to be a drop-in replacement for the DbgHelp library, that understand MinGW symbols.  It provides the same interface as DbgHelp library, but it is able to read the debug information produced by MinGW compilers/linkers.
 
-MgwHelp is used by Dr.MinGW and ExcHndl below to lookup symbols.
+MgwHelp is used by Dr. Mingw and ExcHndl below to lookup symbols.
 
 But the hope is that it will eventually be used by third-party Windows development tools (like debuggers, profilers, etc.) to easily resolve symbol on binaries produced by the MinGW toolchain.
 
@@ -102,7 +102,7 @@ Note that currently [only unhandled exceptions on the thread which called ExcHnd
 
 ### Example
 
-The sample` sample.exe` application uses the second method above.  Copy all DLLs mentioned above to the executable directory.  When you run it, even before general protection fault dialog box appears, it's written to the `sample.RPT` file a report of the fault.
+The sample `sample.exe` application uses the second method above.  Copy all DLLs mentioned above to the executable directory.  When you run it, even before general protection fault dialog box appears, it's written to the `sample.RPT` file a report of the fault.
 
 Here is how `sample.RPT` should look like:
 
@@ -131,7 +131,7 @@ Here is how `sample.RPT` should look like:
 
 ## CatchSegv
 
-Dr. Mingw also includes a Windows replica of GLIBC's `catchsegv` utility, which enables you to run a program, dumping a stack backtrace on any fatal exception.  Dr. Mingw's catchsegv has additional features:
+Dr. Mingw also includes a Windows replica of GLIBC's `catchsegv` utility, which enables you to run a program, dumping a stack backtrace on any fatal exception.  Dr. Mingw's CatchSegv has additional features:
 
 * will collect and dump all `OutputDebugString` messages to stderr
 
@@ -141,7 +141,7 @@ Dr. Mingw also includes a Windows replica of GLIBC's `catchsegv` utility, which 
 
 * allows to specify a time out
 
-All the above make Dr. Mingw's catchsegv ideally suited for test automation.
+All the above make Dr. Mingw's CatchSegv ideally suited for test automation.
 
 Here's the how to use it:
 
@@ -162,7 +162,7 @@ Here's the how to use it:
 
 ### Why do I get a different stack trace from your example?
 
-Make sure you don't use Dr.Mingw and exchndl at the same time -- the latter seems to interfere with the former by some obscure reason.
+Make sure you don't use Dr. Mingw and ExcHndl at the same time -- the latter seems to interfere with the former by some obscure reason.
 
 ### Which options should I pass to GCC/Clang when compiling?
 
@@ -174,7 +174,7 @@ This options are _essential_ to produce suitable results are:
 
  * (Clang only) **`-gdwarf-aranges`** : emit DWARF `.debug_aranges` section ([issue 42](https://github.com/jrfonseca/drmingw/issues/42))
 
-You can choose more detailed debug info, e.g., `-g3`, `-ggdb`. But so far I have seen no evidence this will lead to better results, at least as far as Dr.MinGW is concerned.
+You can choose more detailed debug info, e.g., `-g3`, `-ggdb`. But so far I have seen no evidence this will lead to better results, at least as far as Dr. Mingw is concerned.
 
 ### Why are the reported source lines always after the call?
 


### PR DESCRIPTION
- Move space outside code block.
- Consistently format "ExcHndl", except in code blocks.
- Consistently format "CatchSegv", except in code blocks.
- Consistently format "Dr. Mingw", except in code blocks.