### PR TITLE
Add an option to silence OutputDebugString output

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Here's the how to use it:
       -z           write minidumps
       -Z DIRECTORY write minidumps to specified directory
       -H           use debug heap
+      -q           silence messages from OutputDebugString
 
 ## Frequently Asked Questions
 

--- a/src/catchsegv/catchsegv.cpp
+++ b/src/catchsegv/catchsegv.cpp
@@ -151,7 +151,8 @@ Usage(void)
           "  -m           ignore modal dialogs\n"
           "  -z           write minidumps\n"
           "  -Z DIRECTORY write minidumps to specified directory\n"
-          "  -H           use debug heap\n",
+          "  -H           use debug heap\n"
+          "  -q           silence OutputDebugString output\n",
           stderr);
 }
 
@@ -264,7 +265,7 @@ wmain(int argc, wchar_t **argv)
 
     bool debugHeap = false;
     while (1) {
-        int opt = getoptW(argc, argv, L"?1dhHmt:zZ:v");
+        int opt = getoptW(argc, argv, L"?1dhHmt:zZ:vq");
 
         switch (opt) {
         case L'h':
@@ -294,6 +295,9 @@ wmain(int argc, wchar_t **argv)
         case L'Z':
             debugOptions.minidump = true;
             debugOptions.minidumpDir = optarg;
+            break;
+        case L'q':
+            debugOptions.no_debug_string = true;
             break;
         case L'?':
             if (optopt == L'?') {

--- a/src/catchsegv/catchsegv.cpp
+++ b/src/catchsegv/catchsegv.cpp
@@ -152,7 +152,7 @@ Usage(void)
           "  -z           write minidumps\n"
           "  -Z DIRECTORY write minidumps to specified directory\n"
           "  -H           use debug heap\n"
-          "  -q           silence OutputDebugString output\n",
+          "  -q           silence messages from OutputDebugString\n",
           stderr);
 }
 

--- a/src/common/debugger.cpp
+++ b/src/common/debugger.cpp
@@ -736,6 +736,7 @@ DebugMainLoop(void)
                 lprintf("OUTPUT_DEBUG_STRING PID=%lu TID=%lu\n", DebugEvent.dwProcessId,
                         DebugEvent.dwThreadId);
             }
+            if (debugOptions.no_debug_string) break;
 
             pProcessInfo = &g_Processes[DebugEvent.dwProcessId];
 

--- a/src/common/debugger.h
+++ b/src/common/debugger.h
@@ -31,6 +31,7 @@ struct DebugOptions {
     const wchar_t *minidumpDir = nullptr;
     HANDLE hEvent = nullptr; // Signal an event after process is attached
     DWORD dwThreadId = 0;    // Resume thread after process is attached
+    bool no_debug_string = false; // Silence OutputDebugString messages
 };
 
 EXTERN_C DebugOptions debugOptions;


### PR DESCRIPTION
Hi! I would like to use `catchsegv` to debug crashes during [automatic checks of R packages](https://cran.r-project.org/doc/manuals/R-exts.html#Checking-packages) on Windows.

Some applications used by R during the check (MSYS compilers, MiKTeX) output a lot of distracting information via OutputDebugString(), so I added a flag to the debugger options and to `catchsegv` to silence it.

Please let me know if my changes need to be improved before they can be merged.