### PR TITLE
Line number

### DIFF
--- a/src/mgwhelp/dwarf_find.cpp
+++ b/src/mgwhelp/dwarf_find.cpp
@@ -606,7 +606,6 @@ create_aranges(Dwarf_Debug dbg, std::vector<My_Arange *> &myrec, Dwarf_Error *er
     Dwarf_Unsigned typeoffset = 0;
     Dwarf_Unsigned next_cu_header = 0;
     Dwarf_Half header_cu_type = 0;
-    Dwarf_Bool is_info = TRUE;
     int res = DW_DLV_OK;
 
     while (true) {
@@ -614,7 +613,7 @@ create_aranges(Dwarf_Debug dbg, std::vector<My_Arange *> &myrec, Dwarf_Error *er
         Dwarf_Unsigned cu_header_length = 0;
 
         memset(&signature, 0, sizeof(signature));
-        res = dwarf_next_cu_header_e(dbg, is_info, &cu_die, &cu_header_length, &version_stamp,
+        res = dwarf_next_cu_header_e(dbg, TRUE, &cu_die, &cu_header_length, &version_stamp,
                                      &abbrev_offset, &address_size, &offset_size, &extension_size,
                                      &signature, &typeoffset, &next_cu_header, &header_cu_type,
                                      error);
@@ -622,19 +621,12 @@ create_aranges(Dwarf_Debug dbg, std::vector<My_Arange *> &myrec, Dwarf_Error *er
             return res;
         }
         if (res == DW_DLV_NO_ENTRY) {
-            if (is_info == TRUE) {
-                /*  Done with .debug_info, now check for
-                    .debug_types. */
-                is_info = FALSE;
-                continue;
-            }
             /*  No more CUs to read! Never found
-                what we were looking for in either
-                .debug_info or .debug_types. */
+                what we were looking for in .debug_info. */
             return res;
         }
         /*  We have the cu_die . */
-        res = record_die(dbg, cu_die, is_info, 0, myrec, error);
+        res = record_die(dbg, cu_die, TRUE, 0, myrec, error);
         dwarf_dealloc_die(cu_die);
     }
     return res;

--- a/src/mgwhelp/dwarf_find.cpp
+++ b/src/mgwhelp/dwarf_find.cpp
@@ -578,6 +578,7 @@ record_die(Dwarf_Debug dbg,
         res = dwarf_attr(cur_die, DW_AT_ranges, &attr, error);
         if (res != DW_DLV_OK)
             return res;
+        dwarf_dealloc_attribute(attr);
         res = dwarf_get_version_of_die(cur_die, &version, &offset_size);
         if (res != DW_DLV_OK)
             return res;


### PR DESCRIPTION
I think I have fixed it properly this time, but I will leave it as draft for a while.

I will explain what the problem was. It has something to do with sequences, but the previous fix was wrong.

I am executing
```
addr2line.exe -C -e bin\rpcs3.exe -f 0x1f7686c
```
it prints this (I added debug logging)
```
observe
addr > plineaddr && addr < lineaddr: 0x141f7686c > 0x141e80fa2 && 0x141f7686c < 0x14267a920
C:/src/rpcs3/rpcs3/util/types.hpp:924
```
which is wrong.

If we look at `objdump -WL` output we see this

```
C:/src/rpcs3/rpcs3/util/types.hpp:
types.hpp                                921         0x141e80f80               x
types.hpp                                923         0x141e80f8c               x
types.hpp                                923         0x141e80f94               x
types.hpp                                924         0x141e80f9c               x
types.hpp                                  -         0x141e80fa2

C:/msys64/ucrt64/include/c++/15.2.0/bits/stl_algobase.h:
stl_algobase.h                           234         0x14267a920               x
```

It compares two addresses from difference sequences.

It should have found this instead
```
C:/src/rpcs3/rpcs3/util/atomic.hpp:
atomic.hpp                              1315         0x141f7686c               x
```

The solution is to reset the search each time we encounter the end of sequence `DW_LNE_end_sequence`. This is what libdwarf has to say
```c
/*  At the end of any contiguous line-table there may be
    a DW_LNE_end_sequence operator.
    This returns non-zero thru *return_bool
    if and only if this 'line' entry was a DW_LNE_end_sequence.

    Within a compilation unit or function there may be multiple
    line tables, each ending with a DW_LNE_end_sequence.
    Each table describes a contiguous region.
    Because compilers may split function code up in arbitrary ways
    compilers may need to emit multiple contigous regions (ie
    line tables) for a single function.
    See the DWARF3 spec section 6.2.  */
```
```c
/*  Each 'line' entry has a line-number.
    If the entry is a DW_LNE_end_sequence the line-number is
    meaningless (see dwarf_lineendsequence(), just above).  */
```
```c
/*  Each 'line' entry has a file-number, an index
    into the file table.
    If the entry is a DW_LNE_end_sequence the index is
    meaningless (see dwarf_lineendsequence(), just above).
```
If we find a `DW_LNE_end_sequence` we ignore the file and line information and reset the state of the loop so that in never compares addresses from different sequence or line-tables as libdwarf calls it.