### PR TITLE
use VSCode compatible format for line references

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ Here is how `sample.RPT` should look like:
     74D2ECC0 0028FE50 00403064 00000000  msvcrt.dll!_strxfrm_l
     74D2EDC8 74D2E991 00403064 00000000  msvcrt.dll!sscanf
     74D2ED67 00403067 00403064 00000001  msvcrt.dll!sscanf
-    004013DE 00000008 60000000 40166666  sample.exe!Function  [z:\projects\drmingw\sample/sample.cpp @ 12]
-    00401D3E 00000004 40B33333 0028FF08  sample.exe!Class::StaticMethod(int, float)  [z:\projects\drmingw\sample/sample.cpp @ 17]
-    00401D5E 00401970 00714458 0000000C  sample.exe!Class::Method()  [z:\projects\drmingw\sample/sample.cpp @ 21]
-    004013F9 00000001 00572F38 00571B38  sample.exe!main  [z:\projects\drmingw\sample/sample.cpp @ 27]
+    004013DE 00000008 60000000 40166666  sample.exe!Function  [z:\projects\drmingw\sample/sample.cpp:12]
+    00401D3E 00000004 40B33333 0028FF08  sample.exe!Class::StaticMethod(int, float)  [z:\projects\drmingw\sample/sample.cpp:17]
+    00401D5E 00401970 00714458 0000000C  sample.exe!Class::Method()  [z:\projects\drmingw\sample/sample.cpp:21]
+    004013F9 00000001 00572F38 00571B38  sample.exe!main  [z:\projects\drmingw\sample/sample.cpp:27]
     004010FD 7EFDE000 F769D382 00000000  sample.exe
     77269F42 00401280 7EFDE000 00000000  ntdll.dll!RtlInitializeExceptionChain
     77269F15 00401280 7EFDE000 00000000  ntdll.dll!RtlInitializeExceptionChain
@@ -188,8 +188,6 @@ This options are _essential_ to produce suitable results are:
  * **`-g`** : produce debugging information
 
  * **`-fno-omit-frame-pointer`** : use the frame pointer (frame pointer usage is disabled by default in some architectures like `x86_64` and for some optimization levels; and it may be impossible to walk the call stack without it)
-
- * (Clang only) **`-gdwarf-aranges`** : emit DWARF `.debug_aranges` section ([issue 42](https://github.com/jrfonseca/drmingw/issues/42))
 
 You can choose more detailed debug info, e.g., `-g3`, `-ggdb`. But so far I have seen no evidence this will lead to better results, at least as far as Dr. Mingw is concerned.
 

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -323,7 +323,7 @@ dumpStack(HANDLE hProcess, HANDLE hThread, const CONTEXT *pContext)
                 bLine =
                     GetLineFromAddr(hProcess, AddrPC + nudge, szFileName, _countof(szFileName), &dwLineNumber);
                 if (bLine) {
-                    lprintf(L"  [%ls @ %ld]", szFileName, dwLineNumber);
+                    lprintf(L"  [%ls:%ld]", szFileName, dwLineNumber);
                 }
             } else {
                 lprintf(L"!0x%I64x", AddrPC - (DWORD64)(INT_PTR)hModule);

--- a/tests/apps/access_violation.c
+++ b/tests/apps/access_violation.c
@@ -33,5 +33,5 @@ main(int argc, char *argv[])
     return 0;
 }
 
-// CHECK_STDERR: /  access_violation\.exe\!main\+0x[0-9a-f]+  \[.*\baccess_violation\.c @ 31\]/
+// CHECK_STDERR: /  access_violation\.exe\!main\+0x[0-9a-f]+  \[.*\baccess_violation\.c:31\]/
 // CHECK_EXIT_CODE: 0xc0000005

--- a/tests/apps/access_violation_cxx.cpp
+++ b/tests/apps/access_violation_cxx.cpp
@@ -41,5 +41,5 @@ main(int argc, char *argv[])
     return 0;
 }
 
-// CHECK_STDERR: /  access_violation_cxx\.exe\!test\+0x[0-9a-f]+  \[.*\baccess_violation_cxx\.cpp @ 34\]/
+// CHECK_STDERR: /  access_violation_cxx\.exe\!test\+0x[0-9a-f]+  \[.*\baccess_violation_cxx\.cpp:34\]/
 // CHECK_EXIT_CODE: 0xc0000005

--- a/tests/apps/cxx_inline.cpp
+++ b/tests/apps/cxx_inline.cpp
@@ -29,5 +29,5 @@ int main()
     return l != 0;
 }
 
-// CHECK_STDERR: /  cxx_inline\.exe\!main\+0x[0-9a-f]+  \[.*\bcxx_inline\.cpp @ (21|28)\]/
+// CHECK_STDERR: /  cxx_inline\.exe\!main\+0x[0-9a-f]+  \[.*\bcxx_inline\.cpp:(21|28)\]/
 // CHECK_EXIT_CODE: 0xc0000005

--- a/tests/apps/int3.c
+++ b/tests/apps/int3.c
@@ -35,5 +35,5 @@ main(int argc, char *argv[])
     return 0;
 }
 
-// CHECK_STDERR: /  int3\.exe\!main\+0x[0-9a-f]+  \[.*\bint3\.c @ 33\]/
+// CHECK_STDERR: /  int3\.exe\!main\+0x[0-9a-f]+  \[.*\bint3\.c:33\]/
 // CHECK_EXIT_CODE: 0x80000003

--- a/tests/apps/int_divide_by_zero.c
+++ b/tests/apps/int_divide_by_zero.c
@@ -36,5 +36,5 @@ main(int argc, char *argv[])
     return res.quot;
 }
 
-// CHECK_STDERR: /  int_divide_by_zero\.exe\!main\+0x[0-9a-f]+  \[.*\bint_divide_by_zero\.c @ 35\]/
+// CHECK_STDERR: /  int_divide_by_zero\.exe\!main\+0x[0-9a-f]+  \[.*\bint_divide_by_zero\.c:35\]/
 // CHECK_EXIT_CODE: 0xC0000094

--- a/tests/apps/int_overflow.c
+++ b/tests/apps/int_overflow.c
@@ -36,4 +36,4 @@ main(int argc, char *argv[])
     return res.quot;
 }
 
-// CHECK_STDERR: /  int_overflow\.exe\!main\+0x[0-9a-f]+  \[.*\bint_overflow\.c @ 35\]/
+// CHECK_STDERR: /  int_overflow\.exe\!main\+0x[0-9a-f]+  \[.*\bint_overflow\.c:35\]/

--- a/tests/apps/seh_unhandled.c
+++ b/tests/apps/seh_unhandled.c
@@ -46,5 +46,5 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdS
     return 0;
 }
 
-// CHECK_STDERR: /  seh_unhandled\.exe\!WinMain(@16)?\+0x[0-9a-f]+  \[.*\bseh_unhandled\.c @ 44\]/
+// CHECK_STDERR: /  seh_unhandled\.exe\!WinMain(@16)?\+0x[0-9a-f]+  \[.*\bseh_unhandled\.c:44\]/
 // CHECK_EXIT_CODE: 0xE0000001

--- a/tests/apps/stack_buffer_overflow.c
+++ b/tests/apps/stack_buffer_overflow.c
@@ -38,4 +38,4 @@ int main()
 #endif
 }
 
-// CHECK_STDERR: /  stack_buffer_overflow\.exe\!main\+0x[0-9a-f]+  \[.*\bstack_buffer_overflow\.c @ [0-9]+\]/
+// CHECK_STDERR: /  stack_buffer_overflow\.exe\!main\+0x[0-9a-f]+  \[.*\bstack_buffer_overflow\.c:[0-9]+\]/

--- a/tests/apps/stack_overflow.c
+++ b/tests/apps/stack_overflow.c
@@ -71,6 +71,6 @@ int main()
     return 0;
 }
 
-// CHECK_STDERR: /  stack_overflow\.exe\!factorial\+0x[0-9a-f]+  \[.*\bstack_overflow\.c @ 38\]/
-// CHECK_STDERR: /  stack_overflow\.exe\!main\+0x[0-9a-f]+  \[.*\bstack_overflow\.c @ 69\]/
+// CHECK_STDERR: /  stack_overflow\.exe\!factorial\+0x[0-9a-f]+  \[.*\bstack_overflow\.c:38\]/
+// CHECK_STDERR: /  stack_overflow\.exe\!main\+0x[0-9a-f]+  \[.*\bstack_overflow\.c:69\]/
 // CHECK_EXIT_CODE: 0xc00000fd

--- a/tests/apps/ud2.c
+++ b/tests/apps/ud2.c
@@ -48,5 +48,5 @@ main(int argc, char *argv[])
     return 0;
 }
 
-// CHECK_STDERR: /  ud2\.exe\!main\+0x[0-9a-f]+  \[.*\bud2\.c @ 46\]/
+// CHECK_STDERR: /  ud2\.exe\!main\+0x[0-9a-f]+  \[.*\bud2\.c:46\]/
 // CHECK_EXIT_CODE: 0xC000001D

--- a/tests/apps/unicØde.c
+++ b/tests/apps/unicØde.c
@@ -40,5 +40,5 @@ main(int argc, char *argv[])
     return 0;
 }
 
-// CHECK_STDERR: /  unicØde\.exe\!main\+0x[0-9a-f]+  \[.*\bunicØde\.c @ 38\]/
+// CHECK_STDERR: /  unicØde\.exe\!main\+0x[0-9a-f]+  \[.*\bunicØde\.c:38\]/
 // CHECK_EXIT_CODE: 0x80000003

--- a/tests/test_exchndl.h
+++ b/tests/test_exchndl.h
@@ -150,10 +150,10 @@ main(int argc, char **argv)
 
     if (!setjmp(g_JmpBuf) ) {
 #if !TEST_UNICODE
-        _snprintf(g_szExceptionLinePattern, sizeof g_szExceptionLinePattern, "%s @ %u]",
+        _snprintf(g_szExceptionLinePattern, sizeof g_szExceptionLinePattern, "%s:%u]",
                   PathFindFileNameA(__FILE__), __LINE__); *((volatile int *)0) = 0; LINE_BARRIER
 #else
-        _snprintf(g_szExceptionLinePattern, sizeof g_szExceptionLinePattern, "%S @ %u]",
+        _snprintf(g_szExceptionLinePattern, sizeof g_szExceptionLinePattern, "%S:%u]",
                   PathFindFileNameW(WFILE), __LINE__); *((volatile int *)0) = 0; LINE_BARRIER
 #endif // !TEST_UNICODE
         test_line(false, "longjmp"); exit(1);


### PR DESCRIPTION
I like millions other people use VScode extensively. Sadly it does not understand the drmingw format for line refs.
```
access_violation_cxx.cpp @ 34
```
Instead it expects the following format
```
access_violation_cxx.cpp:34
```